### PR TITLE
Explicitly add pyyaml as dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ PapersBot was inspired by (and borrows some code from) [feedr](https://github.co
 
 ## Requirements
 
-Python 3 and the following modules: [beautifulsoup4](https://pypi.org/project/beautifulsoup4/), [feedparser](https://github.com/kurtmckee/feedparser), [tweepy](https://github.com/tweepy/tweepy).
+Python 3 and the following modules: [pyyaml](https://pyyaml.org/), [beautifulsoup4](https://pypi.org/project/beautifulsoup4/), [feedparser](https://github.com/kurtmckee/feedparser), [tweepy](https://github.com/tweepy/tweepy).
 
-If you have Python 3 installed, you can install those modules with  `pip install bs4 feedparser tweepy`.
+If you have Python 3 installed, you can install those modules with  `pip install pyyaml bs4 feedparser tweepy`.
 
 ## Setup
 


### PR DESCRIPTION
With just the suggested packages in a new virtual env I got

`ModuleNotFoundError: No module named 'yaml'`